### PR TITLE
Html Tag Handling Management

### DIFF
--- a/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/HtmlCharCodeConverter.kt
+++ b/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/HtmlCharCodeConverter.kt
@@ -31,9 +31,11 @@ class HtmlCharCodeConverter(private val partId: String) {
         return result.toString()
     }
 
+    // Should probably generalise the replacements of "#xxx" style codes.
     private fun convertCharCode(code: String): String = when (code) {
         "#38", "amp" -> "&"
         "#39", "apos" -> "'"
+        "#8195", "emsp" -> "\u2003"
         else -> {
             Log.w(TAG, "Unhandled html character code: &$code;")
             FirestoreDataInterface.insertUnhandledCharCode(partId, code)

--- a/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/HtmlTagApplier.kt
+++ b/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/HtmlTagApplier.kt
@@ -1,28 +1,15 @@
 package com.ytrewqwert.yetanotherjnovelreader.data.htmlparser
 
-import android.graphics.Typeface
-import android.text.Html
-import android.text.Layout
-import android.text.Spannable
 import android.text.SpannableStringBuilder
-import android.text.style.AlignmentSpan
-import android.text.style.LeadingMarginSpan
-import android.text.style.RelativeSizeSpan
-import android.text.style.StyleSpan
-import android.util.Log
-import com.ytrewqwert.yetanotherjnovelreader.data.firebase.FirestoreDataInterface
+import com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.lonetags.LoneTagApplier
+import com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.pairtags.PairTagApplier
 
 /**
  * Class for processing html tags.
  *
- * @property[partId] The source part to attribute any unhandled tags to when logging.
+ * @param[partId] The source part to attribute any unhandled tags to when logging.
  */
 class HtmlTagApplier(private val partId: String) {
-    companion object {
-        private const val TAG = "HtmlTagApplier"
-        private val HEADING_SIZES = arrayOf(1.5f, 1.4f, 1.3f, 1.2f, 1.1f, 1f)
-    }
-
     /**
      * Formats [tagContents] based on an open/close html tag pair.
      *
@@ -33,18 +20,7 @@ class HtmlTagApplier(private val partId: String) {
     ) {
         val label = tagLabelTokens[0]
         val args = tagLabelTokens.subList(1, tagLabelTokens.size)
-
-        when (label) {
-            "h1", "h2", "h3", "h4", "h5", "h6" -> applyTagH(args, tagContents, label[1] - '0')
-            "p" -> applyTagP(args, tagContents)
-            "b" -> applyTagB(args, tagContents)
-            "em" -> applyTagEm(args, tagContents)
-            else -> {
-                Log.w(TAG, "Unhandled html tag: $label")
-                FirestoreDataInterface.insertUnhandledHtmlTag(partId, "$label")
-                warnIfArgsNotEmpty(label, args)
-            }
-        }
+        PairTagApplier.getApplier(label, partId).apply(args, tagContents)
     }
 
     /**
@@ -57,96 +33,6 @@ class HtmlTagApplier(private val partId: String) {
     ): SpannableStringBuilder {
         val label = tagLabelTokens[0]
         val args = tagLabelTokens.subList(1, tagLabelTokens.size)
-        return when (label) {
-            "br" -> applyTagBr(args)
-            "img" -> applyTagImg(tagLabelTokens)
-            else -> {
-                Log.w(TAG, "Unhandled html tag: <${tagLabelTokens.joinToString(" ")} >")
-                FirestoreDataInterface.insertUnhandledHtmlTag(partId, "$label")
-                warnIfArgsNotEmpty(label, args)
-                SpannableStringBuilder(label)
-            }
-        }
-    }
-
-    /* Pair tag handlers */
-
-    private fun applyTagH(args: List<CharSequence>, contents: SpannableStringBuilder, hSize: Int) {
-        warnIfArgsNotEmpty("h$hSize", args)
-        applyHeaderSpans(contents, hSize)
-        contents.insert(0, "\n")
-        contents.append("\n")
-    }
-
-    private fun applyTagP(args: List<CharSequence>, contents: SpannableStringBuilder) {
-        var centered = false
-        for (arg in args) {
-            when (arg) {
-                "class=\"centerp\"" -> {
-                    applySpans(contents, AlignmentSpan.Standard(Layout.Alignment.ALIGN_CENTER))
-                    centered = true
-                }
-                else -> {
-                    Log.w(TAG, "Unhandled arg for tag \"p\": $arg")
-                    FirestoreDataInterface.insertUnhandledHtmlArg(partId, "p", "$arg")
-                }
-            }
-        }
-        if (!centered) {
-            applySpans(contents, LeadingMarginSpan.Standard(100, 0))
-        }
-        contents.append("\n")
-    }
-
-    private fun applyTagB(args: List<CharSequence>, contents: SpannableStringBuilder) {
-        warnIfArgsNotEmpty("b", args)
-        applySpans(contents, StyleSpan(Typeface.BOLD))
-    }
-
-    private fun applyTagEm(args: List<CharSequence>, contents: SpannableStringBuilder) {
-        warnIfArgsNotEmpty("em", args)
-        applySpans(contents, StyleSpan(Typeface.ITALIC))
-    }
-
-    /* Lone tag handlers */
-
-    private fun applyTagBr(args: List<CharSequence>): SpannableStringBuilder {
-        warnIfArgsNotEmpty("br", args)
-        return SpannableStringBuilder("\n")
-    }
-
-    private fun applyTagImg(tokens: List<CharSequence>): SpannableStringBuilder {
-        // Use the built-in parser to inject a placeholder image.
-        val imgSpan = Html.fromHtml("<${tokens.joinToString(" ")} >", 0)
-        return SpannableStringBuilder(imgSpan).apply {
-            // Add extra spacing between image and surrounding content
-            insert(0, "\n")
-            append("\n\n")
-        }
-    }
-
-    /* Other stuff */
-
-    private fun applyHeaderSpans(contents: SpannableStringBuilder, headerNum: Int) {
-        applySpans(
-            contents,
-            RelativeSizeSpan(HEADING_SIZES[headerNum - 1]),
-            StyleSpan(Typeface.BOLD)
-        )
-        contents.append("\n")
-    }
-
-    private fun applySpans(target: Spannable, vararg spans: Any) {
-        for (span in spans) {
-            target.setSpan(span, 0, target.length, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
-        }
-    }
-
-    private fun warnIfArgsNotEmpty(label: CharSequence, args: List<CharSequence>) {
-        if (args.isEmpty()) return
-        Log.w(TAG, "Unhandled args for tag \"$label\": $args")
-        for (arg in args) {
-            FirestoreDataInterface.insertUnhandledHtmlArg(partId, "$label", "$arg")
-        }
+        return LoneTagApplier.getApplier(label, partId).apply(args)
     }
 }

--- a/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/HtmlTagApplier.kt
+++ b/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/HtmlTagApplier.kt
@@ -1,8 +1,8 @@
 package com.ytrewqwert.yetanotherjnovelreader.data.htmlparser
 
 import android.text.SpannableStringBuilder
-import com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.lonetags.LoneTagApplier
-import com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.pairtags.PairTagApplier
+import com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.LoneTagApplier
+import com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.PairTagApplier
 
 /**
  * Class for processing html tags.

--- a/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/HtmlTagApplier.kt
+++ b/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/HtmlTagApplier.kt
@@ -13,26 +13,26 @@ class HtmlTagApplier(private val partId: String) {
     /**
      * Formats [tagContents] based on an open/close html tag pair.
      *
-     * @param[tagLabelTokens] A list containing the tag's label followed by any provided arguments.
+     * @param[tagLabel] The tag's label (e.g. 'p' for paragraphs)
+     * @param[tagArgs] A list of pairs grouping any arguments with their values.
      */
     fun applyTagPair(
-        tagLabelTokens: List<CharSequence>, tagContents: SpannableStringBuilder
+        tagLabel: CharSequence,
+        tagArgs: List<Pair<CharSequence, CharSequence>>,
+        tagContents: SpannableStringBuilder
     ) {
-        val label = tagLabelTokens[0]
-        val args = tagLabelTokens.subList(1, tagLabelTokens.size)
-        PairTagApplier.getApplier(label, partId).apply(args, tagContents)
+        PairTagApplier.getApplier(tagLabel, partId).apply(tagArgs, tagContents)
     }
 
     /**
      * Returns a [SpannableStringBuilder] representing the provided self-closing html tag.
      *
-     * @param[tagLabelTokens] A list containing the tag's label followed by any provided arguments.
+     * @param[tagLabel] The tag's label (e.g. 'br' for a line break)
+     * @param[tagArgs] A list of pairs grouping any arguments with their values.
      */
     fun applyLoneTag(
-        tagLabelTokens: List<CharSequence>
+        tagLabel: CharSequence, tagArgs: List<Pair<CharSequence, CharSequence>>
     ): SpannableStringBuilder {
-        val label = tagLabelTokens[0]
-        val args = tagLabelTokens.subList(1, tagLabelTokens.size)
-        return LoneTagApplier.getApplier(label, partId).apply(args)
+        return LoneTagApplier.getApplier(tagLabel, partId).apply(tagArgs)
     }
 }

--- a/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/LoneTagApplier.kt
+++ b/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/LoneTagApplier.kt
@@ -1,7 +1,7 @@
-package com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.lonetags
+package com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags
 
 import android.text.SpannableStringBuilder
-import com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.TagApplier
+import com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.lonetags.*
 
 /**
  * *Interface* for the application of self-closing html tags.

--- a/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/PairTagApplier.kt
+++ b/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/PairTagApplier.kt
@@ -1,7 +1,7 @@
-package com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.pairtags
+package com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags
 
 import android.text.SpannableStringBuilder
-import com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.TagApplier
+import com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.pairtags.*
 
 /**
  * *Interface* for the application of open/close html tag pairs.
@@ -23,6 +23,7 @@ abstract class PairTagApplier(partId: CharSequence) : TagApplier(partId) {
             "em" -> EmPairTagApplier(partId)
             "u" -> UPairTagApplier(partId)
             "s" -> SPairTagApplier(partId)
+            "sup" -> SupPairTagApplier(partId)
             else -> DummyPairTagApplier(partId, tag)
         }
     }

--- a/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/TagApplier.kt
+++ b/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/TagApplier.kt
@@ -1,0 +1,29 @@
+package com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags
+
+import android.util.Log
+import com.ytrewqwert.yetanotherjnovelreader.data.firebase.FirestoreDataInterface
+
+/**
+ * Parent class that exposes methods for subclasses to report unhandled html tag arguments.
+ *
+ * @param[partId] The id of the source part to attribute unhandled arguments to.
+ */
+abstract class TagApplier(private val partId: CharSequence) {
+    companion object {
+        private const val TAG = "TagApplier"
+    }
+
+    /** Logs any unhandled [args] from a given html [tag] to the linked Firestore. */
+    protected fun reportUnhandledArg(tag: CharSequence, vararg args: CharSequence) {
+        for (arg in args) {
+            FirestoreDataInterface.insertUnhandledHtmlArg("$partId", "$tag", "$arg")
+        }
+    }
+
+    /** Logs a warning and reports any (unhandled) arguments to the linked Firestore. */
+    protected fun warnIfArgsNotEmpty(tag: CharSequence, args: List<CharSequence>) {
+        if (args.isEmpty()) return
+        Log.w(TAG, "Unhandled args for tag \"$tag\": $args")
+        reportUnhandledArg(tag, *args.toTypedArray())
+    }
+}

--- a/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/TagApplier.kt
+++ b/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/TagApplier.kt
@@ -1,5 +1,6 @@
 package com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags
 
+import android.text.Spannable
 import android.util.Log
 import com.ytrewqwert.yetanotherjnovelreader.data.firebase.FirestoreDataInterface
 
@@ -11,6 +12,13 @@ import com.ytrewqwert.yetanotherjnovelreader.data.firebase.FirestoreDataInterfac
 abstract class TagApplier(private val partId: CharSequence) {
     companion object {
         private const val TAG = "TagApplier"
+
+        /** Applies [spans], exclusive-exclusive, to the entire length of [target]. */
+        fun applySpans(target: Spannable, vararg spans: Any) {
+            for (span in spans) {
+                target.setSpan(span, 0, target.length, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
+            }
+        }
     }
 
     /** Logs any unhandled [args] from a given html [tag] to the linked Firestore. */

--- a/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/TagApplier.kt
+++ b/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/TagApplier.kt
@@ -21,9 +21,10 @@ abstract class TagApplier(private val partId: CharSequence) {
     }
 
     /** Logs a warning and reports any (unhandled) arguments to the linked Firestore. */
-    protected fun warnIfArgsNotEmpty(tag: CharSequence, args: List<CharSequence>) {
+    protected fun warnIfArgsNotEmpty(tag: CharSequence, args: List<Pair<CharSequence, CharSequence>>) {
         if (args.isEmpty()) return
         Log.w(TAG, "Unhandled args for tag \"$tag\": $args")
-        reportUnhandledArg(tag, *args.toTypedArray())
+        val combinedTypeValue = args.map { "${it.first}=${it.second}" }
+        reportUnhandledArg(tag, *combinedTypeValue.toTypedArray())
     }
 }

--- a/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/TagArgApplier.kt
+++ b/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/TagArgApplier.kt
@@ -1,0 +1,22 @@
+package com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags
+
+import android.text.SpannableStringBuilder
+import com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.tagargs.ClassTagArgApplier
+
+/** *Interface* for the application of arguments provided to html tags. */
+interface TagArgApplier {
+    /**
+     * Applies the html tag argument's [value] to [contents].
+     *
+     * @return true if the arg was successfully applied and false otherwise.
+     */
+    fun applyArg(value: CharSequence, contents: SpannableStringBuilder): Boolean
+
+    companion object {
+        /** Returns the [TagArgApplier] for [arg], or null if no such applier exists. */
+        fun getApplier(arg: CharSequence): TagArgApplier? = when(arg) {
+            "class" -> ClassTagArgApplier
+            else -> null
+        }
+    }
+}

--- a/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/lonetags/BrLoneTagApplier.kt
+++ b/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/lonetags/BrLoneTagApplier.kt
@@ -1,6 +1,7 @@
 package com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.lonetags
 
 import android.text.SpannableStringBuilder
+import com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.LoneTagApplier
 
 /**
  * LoneTagApplier for the 'br' html tag.

--- a/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/lonetags/BrLoneTagApplier.kt
+++ b/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/lonetags/BrLoneTagApplier.kt
@@ -1,0 +1,15 @@
+package com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.lonetags
+
+import android.text.SpannableStringBuilder
+
+/**
+ * LoneTagApplier for the 'br' html tag.
+ *
+ * @param[partId] The id of the source part to attribute unhandled arguments to.
+ */
+class BrLoneTagApplier(partId: CharSequence) : LoneTagApplier(partId) {
+    override fun apply(args: List<CharSequence>): SpannableStringBuilder {
+        warnIfArgsNotEmpty("br", args)
+        return SpannableStringBuilder("\n")
+    }
+}

--- a/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/lonetags/BrLoneTagApplier.kt
+++ b/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/lonetags/BrLoneTagApplier.kt
@@ -8,7 +8,7 @@ import android.text.SpannableStringBuilder
  * @param[partId] The id of the source part to attribute unhandled arguments to.
  */
 class BrLoneTagApplier(partId: CharSequence) : LoneTagApplier(partId) {
-    override fun apply(args: List<CharSequence>): SpannableStringBuilder {
+    override fun apply(args: List<Pair<CharSequence, CharSequence>>): SpannableStringBuilder {
         warnIfArgsNotEmpty("br", args)
         return SpannableStringBuilder("\n")
     }

--- a/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/lonetags/DummyLoneTagApplier.kt
+++ b/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/lonetags/DummyLoneTagApplier.kt
@@ -18,12 +18,13 @@ class DummyLoneTagApplier(private val partId: CharSequence, private val tag: Cha
         private const val TAG = "DummyPairTagApplier"
     }
 
-    override fun apply(args: List<CharSequence>): SpannableStringBuilder {
+    override fun apply(args: List<Pair<CharSequence, CharSequence>>): SpannableStringBuilder {
         Log.w(TAG, "Unhandled lone html tag: $tag")
         FirestoreDataInterface.insertUnhandledHtmlTag("$partId", "$tag")
         warnIfArgsNotEmpty(tag, args)
-        
-        val fullTag = "<$tag ${args.joinToString(" ")} />"
+
+        val argsCombinedTypeValue = args.map { "${it.first}=${it.second}" }
+        val fullTag = "<$tag ${argsCombinedTypeValue.joinToString(" ")} />"
         return SpannableStringBuilder(fullTag)
     }
 }

--- a/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/lonetags/DummyLoneTagApplier.kt
+++ b/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/lonetags/DummyLoneTagApplier.kt
@@ -3,6 +3,7 @@ package com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.lonetags
 import android.text.SpannableStringBuilder
 import android.util.Log
 import com.ytrewqwert.yetanotherjnovelreader.data.firebase.FirestoreDataInterface
+import com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.LoneTagApplier
 
 /**
  * A dummy LoneTagApplier for unhandled tags. Reports the tag and returns the original tag as a

--- a/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/lonetags/DummyLoneTagApplier.kt
+++ b/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/lonetags/DummyLoneTagApplier.kt
@@ -24,7 +24,7 @@ class DummyLoneTagApplier(private val partId: CharSequence, private val tag: Cha
         warnIfArgsNotEmpty(tag, args)
 
         val argsCombinedTypeValue = args.map { "${it.first}=${it.second}" }
-        val fullTag = "<$tag ${argsCombinedTypeValue.joinToString(" ")} />"
+        val fullTag = "<$tag ${argsCombinedTypeValue.joinToString(" ")}/>"
         return SpannableStringBuilder(fullTag)
     }
 }

--- a/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/lonetags/DummyLoneTagApplier.kt
+++ b/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/lonetags/DummyLoneTagApplier.kt
@@ -1,0 +1,29 @@
+package com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.lonetags
+
+import android.text.SpannableStringBuilder
+import android.util.Log
+import com.ytrewqwert.yetanotherjnovelreader.data.firebase.FirestoreDataInterface
+
+/**
+ * A dummy LoneTagApplier for unhandled tags. Reports the tag and returns the original tag as a
+ * [SpannableStringBuilder].
+ *
+ * @param[partId] The id of the source part to attribute unhandled arguments to.
+ * @param[tag] The name of the unhandled tag.
+ */
+class DummyLoneTagApplier(private val partId: CharSequence, private val tag: CharSequence)
+    : LoneTagApplier(partId) {
+
+    companion object {
+        private const val TAG = "DummyPairTagApplier"
+    }
+
+    override fun apply(args: List<CharSequence>): SpannableStringBuilder {
+        Log.w(TAG, "Unhandled lone html tag: $tag")
+        FirestoreDataInterface.insertUnhandledHtmlTag("$partId", "$tag")
+        warnIfArgsNotEmpty(tag, args)
+        
+        val fullTag = "<$tag ${args.joinToString(" ")} />"
+        return SpannableStringBuilder(fullTag)
+    }
+}

--- a/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/lonetags/HrLoneTagApplier.kt
+++ b/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/lonetags/HrLoneTagApplier.kt
@@ -4,6 +4,7 @@ import android.graphics.Canvas
 import android.graphics.Paint
 import android.text.SpannableStringBuilder
 import android.text.style.ReplacementSpan
+import com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.LoneTagApplier
 
 /**
  * LoneTagApplier for the 'hr' html tag.

--- a/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/lonetags/HrLoneTagApplier.kt
+++ b/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/lonetags/HrLoneTagApplier.kt
@@ -1,0 +1,41 @@
+package com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.lonetags
+
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.text.SpannableStringBuilder
+import android.text.style.ReplacementSpan
+
+/**
+ * LoneTagApplier for the 'hr' html tag.
+ *
+ * @param[partId] The id of the source part to attribute unhandled arguments to.
+ */
+class HrLoneTagApplier(private val partId: CharSequence) : LoneTagApplier(partId) {
+    override fun apply(args: List<Pair<CharSequence, CharSequence>>): SpannableStringBuilder {
+        val result = SpannableStringBuilder("-\n")
+        applySpans(result, HrSpan(1f))
+        return result
+    }
+
+    /**
+     * Replaces the text with a horizontal rule [thickness] pixels thick.
+     *
+     * Credit to [this](https://stackoverflow.com/a/43750749) answer by Vishnu M. on S.O.
+     */
+    private class HrSpan(private val thickness: Float) : ReplacementSpan() {
+        override fun getSize(
+            paint: Paint, text: CharSequence?, start: Int, end: Int, fm: Paint.FontMetricsInt?
+        ): Int = 0
+
+        override fun draw(
+            canvas: Canvas, text: CharSequence?, start: Int, end: Int,
+            x: Float, top: Int, y: Int, bottom: Int, paint: Paint
+        ) {
+            paint.style = Paint.Style.STROKE
+            paint.strokeWidth = thickness
+            val midY = ((top + bottom) / 2).toFloat()
+            canvas.drawLine(0f, midY, canvas.width.toFloat(), midY, paint)
+        }
+
+    }
+}

--- a/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/lonetags/ImgLoneTagApplier.kt
+++ b/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/lonetags/ImgLoneTagApplier.kt
@@ -2,6 +2,7 @@ package com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.lonetags
 
 import android.text.Html
 import android.text.SpannableStringBuilder
+import com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.LoneTagApplier
 
 /**
  * LoneTagApplier for the 'img' html tag.

--- a/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/lonetags/ImgLoneTagApplier.kt
+++ b/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/lonetags/ImgLoneTagApplier.kt
@@ -1,0 +1,21 @@
+package com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.lonetags
+
+import android.text.Html
+import android.text.SpannableStringBuilder
+
+/**
+ * LoneTagApplier for the 'img' html tag.
+ *
+ * @param[partId] The id of the source part to attribute unhandled arguments to.
+ */
+class ImgLoneTagApplier(partId: CharSequence) : LoneTagApplier(partId) {
+    override fun apply(args: List<CharSequence>): SpannableStringBuilder {
+        // Use the built-in parser to inject a placeholder image.
+        val imgSpan = Html.fromHtml("<img ${args.joinToString(" ")} />", 0)
+        return SpannableStringBuilder(imgSpan).apply {
+            // Add extra spacing between image and surrounding content
+            insert(0, "\n")
+            append("\n\n")
+        }
+    }
+}

--- a/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/lonetags/ImgLoneTagApplier.kt
+++ b/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/lonetags/ImgLoneTagApplier.kt
@@ -9,9 +9,10 @@ import android.text.SpannableStringBuilder
  * @param[partId] The id of the source part to attribute unhandled arguments to.
  */
 class ImgLoneTagApplier(partId: CharSequence) : LoneTagApplier(partId) {
-    override fun apply(args: List<CharSequence>): SpannableStringBuilder {
+    override fun apply(args: List<Pair<CharSequence, CharSequence>>): SpannableStringBuilder {
         // Use the built-in parser to inject a placeholder image.
-        val imgSpan = Html.fromHtml("<img ${args.joinToString(" ")} />", 0)
+        val argsCombinedTypeValue = args.map { "${it.first}=${it.second}" }
+        val imgSpan = Html.fromHtml("<img ${argsCombinedTypeValue.joinToString(" ")} />", 0)
         return SpannableStringBuilder(imgSpan).apply {
             // Add extra spacing between image and surrounding content
             insert(0, "\n")

--- a/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/lonetags/LoneTagApplier.kt
+++ b/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/lonetags/LoneTagApplier.kt
@@ -1,0 +1,23 @@
+package com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.lonetags
+
+import android.text.SpannableStringBuilder
+import com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.TagApplier
+
+/**
+ * *Interface* for the application of self-closing html tags.
+ *
+ * @param[partId] The id of the source part to attribute unhandled arguments to.
+ */
+abstract class LoneTagApplier(partId: CharSequence) : TagApplier(partId) {
+    /** Returns a  representation of the html tag with properties specified by [args]. */
+    abstract fun apply(args: List<CharSequence>): SpannableStringBuilder
+
+    companion object {
+        /** Returns the [LoneTagApplier] for [tag], injecting [partId] for its source part. */
+        fun getApplier(tag: CharSequence, partId: CharSequence): LoneTagApplier = when(tag) {
+            "br" -> BrLoneTagApplier(partId)
+            "img" -> ImgLoneTagApplier(partId)
+            else -> DummyLoneTagApplier(partId, tag)
+        }
+    }
+}

--- a/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/lonetags/LoneTagApplier.kt
+++ b/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/lonetags/LoneTagApplier.kt
@@ -10,7 +10,7 @@ import com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.TagApplier
  */
 abstract class LoneTagApplier(partId: CharSequence) : TagApplier(partId) {
     /** Returns a  representation of the html tag with properties specified by [args]. */
-    abstract fun apply(args: List<CharSequence>): SpannableStringBuilder
+    abstract fun apply(args: List<Pair<CharSequence, CharSequence>>): SpannableStringBuilder
 
     companion object {
         /** Returns the [LoneTagApplier] for [tag], injecting [partId] for its source part. */

--- a/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/lonetags/LoneTagApplier.kt
+++ b/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/lonetags/LoneTagApplier.kt
@@ -16,6 +16,7 @@ abstract class LoneTagApplier(partId: CharSequence) : TagApplier(partId) {
         /** Returns the [LoneTagApplier] for [tag], injecting [partId] for its source part. */
         fun getApplier(tag: CharSequence, partId: CharSequence): LoneTagApplier = when(tag) {
             "br" -> BrLoneTagApplier(partId)
+            "hr" -> HrLoneTagApplier(partId)
             "img" -> ImgLoneTagApplier(partId)
             else -> DummyLoneTagApplier(partId, tag)
         }

--- a/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/pairtags/BPairTagApplier.kt
+++ b/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/pairtags/BPairTagApplier.kt
@@ -10,7 +10,9 @@ import android.text.style.StyleSpan
  * @param[partId] The id of the source part to attribute unhandled arguments to.
  */
 class BPairTagApplier(partId: CharSequence) : PairTagApplier(partId) {
-    override fun apply(args: List<Pair<CharSequence, CharSequence>>, contents: SpannableStringBuilder) {
+    override fun apply(
+        args: List<Pair<CharSequence, CharSequence>>, contents: SpannableStringBuilder
+    ) {
         warnIfArgsNotEmpty("b", args)
         applySpans(contents, StyleSpan(Typeface.BOLD))
     }

--- a/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/pairtags/BPairTagApplier.kt
+++ b/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/pairtags/BPairTagApplier.kt
@@ -10,7 +10,7 @@ import android.text.style.StyleSpan
  * @param[partId] The id of the source part to attribute unhandled arguments to.
  */
 class BPairTagApplier(partId: CharSequence) : PairTagApplier(partId) {
-    override fun apply(args: List<CharSequence>, contents: SpannableStringBuilder) {
+    override fun apply(args: List<Pair<CharSequence, CharSequence>>, contents: SpannableStringBuilder) {
         warnIfArgsNotEmpty("b", args)
         applySpans(contents, StyleSpan(Typeface.BOLD))
     }

--- a/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/pairtags/BPairTagApplier.kt
+++ b/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/pairtags/BPairTagApplier.kt
@@ -3,6 +3,7 @@ package com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.pairtags
 import android.graphics.Typeface
 import android.text.SpannableStringBuilder
 import android.text.style.StyleSpan
+import com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.PairTagApplier
 
 /**
  * PairTagApplier for the 'b' html tag.

--- a/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/pairtags/BPairTagApplier.kt
+++ b/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/pairtags/BPairTagApplier.kt
@@ -1,0 +1,17 @@
+package com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.pairtags
+
+import android.graphics.Typeface
+import android.text.SpannableStringBuilder
+import android.text.style.StyleSpan
+
+/**
+ * PairTagApplier for the 'b' html tag.
+ *
+ * @param[partId] The id of the source part to attribute unhandled arguments to.
+ */
+class BPairTagApplier(partId: CharSequence) : PairTagApplier(partId) {
+    override fun apply(args: List<CharSequence>, contents: SpannableStringBuilder) {
+        warnIfArgsNotEmpty("b", args)
+        applySpans(contents, StyleSpan(Typeface.BOLD))
+    }
+}

--- a/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/pairtags/DummyPairTagApplier.kt
+++ b/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/pairtags/DummyPairTagApplier.kt
@@ -1,0 +1,31 @@
+package com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.pairtags
+
+import android.text.SpannableStringBuilder
+import android.util.Log
+import com.ytrewqwert.yetanotherjnovelreader.data.firebase.FirestoreDataInterface
+
+/**
+ * A dummy PairTagApplier for unhandled tags. Reports the tag and pushes the original tag into the
+ * result.
+ *
+ * @param[partId] The id of the source part to attribute unhandled arguments to.
+ * @param[tag] The name of the unhandled tag.
+ */
+class DummyPairTagApplier(private val partId: CharSequence, private val tag: CharSequence)
+    : PairTagApplier(partId) {
+
+    companion object {
+        private const val TAG = "DummyPairTagApplier"
+    }
+
+    override fun apply(args: List<CharSequence>, contents: SpannableStringBuilder) {
+        Log.w(TAG, "Unhandled html tag pair: $tag")
+        FirestoreDataInterface.insertUnhandledHtmlTag("$partId", "$tag")
+        warnIfArgsNotEmpty(tag, args)
+
+        val openTag = "<$tag ${args.joinToString(" ")} />"
+        val closeTag = "<$tag />"
+        contents.insert(0, openTag)
+        contents.append(closeTag)
+    }
+}

--- a/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/pairtags/DummyPairTagApplier.kt
+++ b/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/pairtags/DummyPairTagApplier.kt
@@ -18,12 +18,13 @@ class DummyPairTagApplier(private val partId: CharSequence, private val tag: Cha
         private const val TAG = "DummyPairTagApplier"
     }
 
-    override fun apply(args: List<CharSequence>, contents: SpannableStringBuilder) {
+    override fun apply(args: List<Pair<CharSequence, CharSequence>>, contents: SpannableStringBuilder) {
         Log.w(TAG, "Unhandled html tag pair: $tag")
         FirestoreDataInterface.insertUnhandledHtmlTag("$partId", "$tag")
         warnIfArgsNotEmpty(tag, args)
 
-        val openTag = "<$tag ${args.joinToString(" ")} />"
+        val argsCombinedTypeValue = args.map { "${it.first}=${it.second}" }
+        val openTag = "<$tag ${argsCombinedTypeValue.joinToString(" ")} />"
         val closeTag = "<$tag />"
         contents.insert(0, openTag)
         contents.append(closeTag)

--- a/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/pairtags/DummyPairTagApplier.kt
+++ b/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/pairtags/DummyPairTagApplier.kt
@@ -3,6 +3,7 @@ package com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.pairtags
 import android.text.SpannableStringBuilder
 import android.util.Log
 import com.ytrewqwert.yetanotherjnovelreader.data.firebase.FirestoreDataInterface
+import com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.PairTagApplier
 
 /**
  * A dummy PairTagApplier for unhandled tags. Reports the tag and pushes the original tag into the
@@ -26,7 +27,8 @@ class DummyPairTagApplier(private val partId: CharSequence, private val tag: Cha
         warnIfArgsNotEmpty(tag, args)
 
         val argsCombinedTypeValue = args.map { "${it.first}=${it.second}" }
-        val openTag = "<$tag ${argsCombinedTypeValue.joinToString(" ")}>"
+        val tokens = listOf(tag, *argsCombinedTypeValue.toTypedArray())
+        val openTag = "<${tokens.joinToString(" ")}>"
         val closeTag = "<$tag />"
         contents.insert(0, openTag)
         contents.append(closeTag)

--- a/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/pairtags/DummyPairTagApplier.kt
+++ b/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/pairtags/DummyPairTagApplier.kt
@@ -18,13 +18,15 @@ class DummyPairTagApplier(private val partId: CharSequence, private val tag: Cha
         private const val TAG = "DummyPairTagApplier"
     }
 
-    override fun apply(args: List<Pair<CharSequence, CharSequence>>, contents: SpannableStringBuilder) {
+    override fun apply(
+        args: List<Pair<CharSequence, CharSequence>>, contents: SpannableStringBuilder
+    ) {
         Log.w(TAG, "Unhandled html tag pair: $tag")
         FirestoreDataInterface.insertUnhandledHtmlTag("$partId", "$tag")
         warnIfArgsNotEmpty(tag, args)
 
         val argsCombinedTypeValue = args.map { "${it.first}=${it.second}" }
-        val openTag = "<$tag ${argsCombinedTypeValue.joinToString(" ")} />"
+        val openTag = "<$tag ${argsCombinedTypeValue.joinToString(" ")}>"
         val closeTag = "<$tag />"
         contents.insert(0, openTag)
         contents.append(closeTag)

--- a/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/pairtags/EmPairTagApplier.kt
+++ b/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/pairtags/EmPairTagApplier.kt
@@ -10,7 +10,9 @@ import android.text.style.StyleSpan
  * @param[partId] The id of the source part to attribute unhandled arguments to.
  */
 class EmPairTagApplier(partId: CharSequence) : PairTagApplier(partId) {
-    override fun apply(args: List<Pair<CharSequence, CharSequence>>, contents: SpannableStringBuilder) {
+    override fun apply(
+        args: List<Pair<CharSequence, CharSequence>>, contents: SpannableStringBuilder
+    ) {
         warnIfArgsNotEmpty("em", args)
         applySpans(contents, StyleSpan(Typeface.ITALIC))
     }

--- a/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/pairtags/EmPairTagApplier.kt
+++ b/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/pairtags/EmPairTagApplier.kt
@@ -10,7 +10,7 @@ import android.text.style.StyleSpan
  * @param[partId] The id of the source part to attribute unhandled arguments to.
  */
 class EmPairTagApplier(partId: CharSequence) : PairTagApplier(partId) {
-    override fun apply(args: List<CharSequence>, contents: SpannableStringBuilder) {
+    override fun apply(args: List<Pair<CharSequence, CharSequence>>, contents: SpannableStringBuilder) {
         warnIfArgsNotEmpty("em", args)
         applySpans(contents, StyleSpan(Typeface.ITALIC))
     }

--- a/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/pairtags/EmPairTagApplier.kt
+++ b/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/pairtags/EmPairTagApplier.kt
@@ -3,6 +3,7 @@ package com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.pairtags
 import android.graphics.Typeface
 import android.text.SpannableStringBuilder
 import android.text.style.StyleSpan
+import com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.PairTagApplier
 
 /**
  * PairTagApplier for the 'em' html tag.

--- a/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/pairtags/EmPairTagApplier.kt
+++ b/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/pairtags/EmPairTagApplier.kt
@@ -1,0 +1,17 @@
+package com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.pairtags
+
+import android.graphics.Typeface
+import android.text.SpannableStringBuilder
+import android.text.style.StyleSpan
+
+/**
+ * PairTagApplier for the 'em' html tag.
+ *
+ * @param[partId] The id of the source part to attribute unhandled arguments to.
+ */
+class EmPairTagApplier(partId: CharSequence) : PairTagApplier(partId) {
+    override fun apply(args: List<CharSequence>, contents: SpannableStringBuilder) {
+        warnIfArgsNotEmpty("em", args)
+        applySpans(contents, StyleSpan(Typeface.ITALIC))
+    }
+}

--- a/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/pairtags/HPairTagApplier.kt
+++ b/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/pairtags/HPairTagApplier.kt
@@ -16,7 +16,9 @@ class HPairTagApplier(partId: CharSequence, private val headerSize: Int) : PairT
         private val HEADING_SIZES = arrayOf(1.5f, 1.4f, 1.3f, 1.2f, 1.1f, 1f)
     }
 
-    override fun apply(args: List<Pair<CharSequence, CharSequence>>, contents: SpannableStringBuilder) {
+    override fun apply(
+        args: List<Pair<CharSequence, CharSequence>>, contents: SpannableStringBuilder
+    ) {
         warnIfArgsNotEmpty("h$headerSize", args)
         applySpans(
             contents,

--- a/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/pairtags/HPairTagApplier.kt
+++ b/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/pairtags/HPairTagApplier.kt
@@ -16,7 +16,7 @@ class HPairTagApplier(partId: CharSequence, private val headerSize: Int) : PairT
         private val HEADING_SIZES = arrayOf(1.5f, 1.4f, 1.3f, 1.2f, 1.1f, 1f)
     }
 
-    override fun apply(args: List<CharSequence>, contents: SpannableStringBuilder) {
+    override fun apply(args: List<Pair<CharSequence, CharSequence>>, contents: SpannableStringBuilder) {
         warnIfArgsNotEmpty("h$headerSize", args)
         applySpans(
             contents,

--- a/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/pairtags/HPairTagApplier.kt
+++ b/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/pairtags/HPairTagApplier.kt
@@ -4,6 +4,7 @@ import android.graphics.Typeface
 import android.text.SpannableStringBuilder
 import android.text.style.RelativeSizeSpan
 import android.text.style.StyleSpan
+import com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.PairTagApplier
 
 /**
  * PairTagApplier for header html tags. (i.e. h1 - h6).

--- a/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/pairtags/HPairTagApplier.kt
+++ b/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/pairtags/HPairTagApplier.kt
@@ -1,0 +1,29 @@
+package com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.pairtags
+
+import android.graphics.Typeface
+import android.text.SpannableStringBuilder
+import android.text.style.RelativeSizeSpan
+import android.text.style.StyleSpan
+
+/**
+ * PairTagApplier for header html tags. (i.e. h1 - h6).
+ *
+ * @param[partId] The id of the source part to attribute unhandled arguments to.
+ * @param[headerSize] The header value (i.e. 1 for h1, 2 for h2, etc.)
+ */
+class HPairTagApplier(partId: CharSequence, private val headerSize: Int) : PairTagApplier(partId) {
+    companion object {
+        private val HEADING_SIZES = arrayOf(1.5f, 1.4f, 1.3f, 1.2f, 1.1f, 1f)
+    }
+
+    override fun apply(args: List<CharSequence>, contents: SpannableStringBuilder) {
+        warnIfArgsNotEmpty("h$headerSize", args)
+        applySpans(
+            contents,
+            RelativeSizeSpan(HEADING_SIZES[headerSize - 1]),
+            StyleSpan(Typeface.BOLD)
+        )
+        contents.insert(0, "\n")
+        contents.append("\n\n")
+    }
+}

--- a/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/pairtags/PPairTagApplier.kt
+++ b/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/pairtags/PPairTagApplier.kt
@@ -15,7 +15,9 @@ class PPairTagApplier(partId: CharSequence) : PairTagApplier(partId) {
         private const val TAG = "PPairTagApplier"
     }
 
-    override fun apply(args: List<Pair<CharSequence, CharSequence>>, contents: SpannableStringBuilder) {
+    override fun apply(
+        args: List<Pair<CharSequence, CharSequence>>, contents: SpannableStringBuilder
+    ) {
         applySpans(contents, LeadingMarginSpan.Standard(100, 0)) // Paragraph indentation
         for (arg in args) {
             val (type, value) = arg

--- a/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/pairtags/PPairTagApplier.kt
+++ b/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/pairtags/PPairTagApplier.kt
@@ -1,10 +1,9 @@
 package com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.pairtags
 
-import android.text.Layout
 import android.text.SpannableStringBuilder
-import android.text.style.AlignmentSpan
 import android.text.style.LeadingMarginSpan
 import android.util.Log
+import com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.TagArgApplier
 
 /**
  * PairTagApplier for the 'p' html tag.
@@ -17,32 +16,15 @@ class PPairTagApplier(partId: CharSequence) : PairTagApplier(partId) {
     }
 
     override fun apply(args: List<Pair<CharSequence, CharSequence>>, contents: SpannableStringBuilder) {
-        var putLeadingMargin = true
+        applySpans(contents, LeadingMarginSpan.Standard(100, 0)) // Paragraph indentation
         for (arg in args) {
             val (type, value) = arg
-            when (type) {
-                "class" -> {
-                    val splitValues = value.trim('"').split(' ')
-                    for (v in splitValues) when(v) {
-                        "centerp" -> {
-                            val centerSpan = AlignmentSpan.Standard(Layout.Alignment.ALIGN_CENTER)
-                            applySpans(contents, centerSpan)
-                            putLeadingMargin = false
-                        }
-                        else -> {
-                            Log.w(TAG, "Unhandled arg: $arg")
-                            reportUnhandledArg("p", "$type=\"$v\"")
-                        }
-                    }
-                }
-                else -> {
-                    Log.w(TAG, "Unhandled arg: $arg")
-                    reportUnhandledArg("p", "$type=$value")
-                }
+            val applier = TagArgApplier.getApplier(type)
+            if (applier?.applyArg(value, contents) != true) {
+                Log.w(TAG, "Unhandled arg: $arg")
+                reportUnhandledArg("p", "$type=$value")
+                continue
             }
-        }
-        if (putLeadingMargin) {
-            applySpans(contents, LeadingMarginSpan.Standard(100, 0))
         }
         contents.append("\n")
     }

--- a/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/pairtags/PPairTagApplier.kt
+++ b/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/pairtags/PPairTagApplier.kt
@@ -16,18 +16,28 @@ class PPairTagApplier(partId: CharSequence) : PairTagApplier(partId) {
         private const val TAG = "PPairTagApplier"
     }
 
-    override fun apply(args: List<CharSequence>, contents: SpannableStringBuilder) {
+    override fun apply(args: List<Pair<CharSequence, CharSequence>>, contents: SpannableStringBuilder) {
         var putLeadingMargin = true
         for (arg in args) {
-            when (arg) {
-                "class=\"centerp\"" -> {
-                    val centerSpan = AlignmentSpan.Standard(Layout.Alignment.ALIGN_CENTER)
-                    applySpans(contents, centerSpan)
-                    putLeadingMargin = false
+            val (type, value) = arg
+            when (type) {
+                "class" -> {
+                    val splitValues = value.trim('"').split(' ')
+                    for (v in splitValues) when(v) {
+                        "centerp" -> {
+                            val centerSpan = AlignmentSpan.Standard(Layout.Alignment.ALIGN_CENTER)
+                            applySpans(contents, centerSpan)
+                            putLeadingMargin = false
+                        }
+                        else -> {
+                            Log.w(TAG, "Unhandled arg: $arg")
+                            reportUnhandledArg("p", "$type=\"$v\"")
+                        }
+                    }
                 }
                 else -> {
                     Log.w(TAG, "Unhandled arg: $arg")
-                    reportUnhandledArg("p", "$arg")
+                    reportUnhandledArg("p", "$type=$value")
                 }
             }
         }

--- a/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/pairtags/PPairTagApplier.kt
+++ b/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/pairtags/PPairTagApplier.kt
@@ -1,0 +1,39 @@
+package com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.pairtags
+
+import android.text.Layout
+import android.text.SpannableStringBuilder
+import android.text.style.AlignmentSpan
+import android.text.style.LeadingMarginSpan
+import android.util.Log
+
+/**
+ * PairTagApplier for the 'p' html tag.
+ *
+ * @param[partId] The id of the source part to attribute unhandled arguments to.
+ */
+class PPairTagApplier(partId: CharSequence) : PairTagApplier(partId) {
+    companion object {
+        private const val TAG = "PPairTagApplier"
+    }
+
+    override fun apply(args: List<CharSequence>, contents: SpannableStringBuilder) {
+        var putLeadingMargin = true
+        for (arg in args) {
+            when (arg) {
+                "class=\"centerp\"" -> {
+                    val centerSpan = AlignmentSpan.Standard(Layout.Alignment.ALIGN_CENTER)
+                    applySpans(contents, centerSpan)
+                    putLeadingMargin = false
+                }
+                else -> {
+                    Log.w(TAG, "Unhandled arg: $arg")
+                    reportUnhandledArg("p", "$arg")
+                }
+            }
+        }
+        if (putLeadingMargin) {
+            applySpans(contents, LeadingMarginSpan.Standard(100, 0))
+        }
+        contents.append("\n")
+    }
+}

--- a/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/pairtags/PPairTagApplier.kt
+++ b/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/pairtags/PPairTagApplier.kt
@@ -3,6 +3,7 @@ package com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.pairtags
 import android.text.SpannableStringBuilder
 import android.text.style.LeadingMarginSpan
 import android.util.Log
+import com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.PairTagApplier
 import com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.TagArgApplier
 
 /**

--- a/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/pairtags/PairTagApplier.kt
+++ b/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/pairtags/PairTagApplier.kt
@@ -1,9 +1,7 @@
 package com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.pairtags
 
-import android.text.Spannable
 import android.text.SpannableStringBuilder
 import com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.TagApplier
-import com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.lonetags.LoneTagApplier
 
 /**
  * *Interface* for the application of open/close html tag pairs.
@@ -14,15 +12,8 @@ abstract class PairTagApplier(partId: CharSequence) : TagApplier(partId) {
     /** Applies the html tag pair modified by properties specified by [args] to [contents]. */
     abstract fun apply(args: List<Pair<CharSequence, CharSequence>>, contents: SpannableStringBuilder)
 
-    /** Applies [spans], exclusive-exclusive, to the entire length of [target]. */
-    protected fun applySpans(target: Spannable, vararg spans: Any) {
-        for (span in spans) {
-            target.setSpan(span, 0, target.length, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
-        }
-    }
-
     companion object {
-        /** Returns the [LoneTagApplier] for [tag], injecting [partId] as its source part. */
+        /** Returns the [PairTagApplier] for [tag], injecting [partId] as its source part. */
         fun getApplier(tag: CharSequence, partId: CharSequence): PairTagApplier = when(tag) {
             "h1", "h2", "h3", "h4", "h5", "h6" -> HPairTagApplier(partId, tag[1] - '0')
             "p" -> PPairTagApplier(partId)

--- a/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/pairtags/PairTagApplier.kt
+++ b/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/pairtags/PairTagApplier.kt
@@ -22,6 +22,7 @@ abstract class PairTagApplier(partId: CharSequence) : TagApplier(partId) {
             "b" -> BPairTagApplier(partId)
             "em" -> EmPairTagApplier(partId)
             "u" -> UPairTagApplier(partId)
+            "s" -> SPairTagApplier(partId)
             else -> DummyPairTagApplier(partId, tag)
         }
     }

--- a/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/pairtags/PairTagApplier.kt
+++ b/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/pairtags/PairTagApplier.kt
@@ -1,0 +1,37 @@
+package com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.pairtags
+
+import android.text.Spannable
+import android.text.SpannableStringBuilder
+import com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.TagApplier
+import com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.lonetags.BrLoneTagApplier
+import com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.lonetags.DummyLoneTagApplier
+import com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.lonetags.ImgLoneTagApplier
+import com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.lonetags.LoneTagApplier
+
+/**
+ * *Interface* for the application of open/close html tag pairs.
+ *
+ * @param[partId] The id of the source part to attribute unhandled arguments to.
+ */
+abstract class PairTagApplier(partId: CharSequence) : TagApplier(partId) {
+    /** Applies the html tag pair modified by properties specified by [args] to [contents]. */
+    abstract fun apply(args: List<CharSequence>, contents: SpannableStringBuilder)
+
+    /** Applies [spans], exclusive-exclusive, to the entire length of [target]. */
+    protected fun applySpans(target: Spannable, vararg spans: Any) {
+        for (span in spans) {
+            target.setSpan(span, 0, target.length, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
+        }
+    }
+
+    companion object {
+        /** Returns the [LoneTagApplier] for [tag], injecting [partId] as its source part. */
+        fun getApplier(tag: CharSequence, partId: CharSequence): PairTagApplier = when(tag) {
+            "h1", "h2", "h3", "h4", "h5", "h6" -> HPairTagApplier(partId, tag[1] - '0')
+            "p" -> PPairTagApplier(partId)
+            "b" -> BPairTagApplier(partId)
+            "em" -> EmPairTagApplier(partId)
+            else -> DummyPairTagApplier(partId, tag)
+        }
+    }
+}

--- a/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/pairtags/PairTagApplier.kt
+++ b/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/pairtags/PairTagApplier.kt
@@ -10,7 +10,9 @@ import com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.TagApplier
  */
 abstract class PairTagApplier(partId: CharSequence) : TagApplier(partId) {
     /** Applies the html tag pair modified by properties specified by [args] to [contents]. */
-    abstract fun apply(args: List<Pair<CharSequence, CharSequence>>, contents: SpannableStringBuilder)
+    abstract fun apply(
+        args: List<Pair<CharSequence, CharSequence>>, contents: SpannableStringBuilder
+    )
 
     companion object {
         /** Returns the [PairTagApplier] for [tag], injecting [partId] as its source part. */
@@ -19,6 +21,7 @@ abstract class PairTagApplier(partId: CharSequence) : TagApplier(partId) {
             "p" -> PPairTagApplier(partId)
             "b" -> BPairTagApplier(partId)
             "em" -> EmPairTagApplier(partId)
+            "u" -> UPairTagApplier(partId)
             else -> DummyPairTagApplier(partId, tag)
         }
     }

--- a/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/pairtags/PairTagApplier.kt
+++ b/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/pairtags/PairTagApplier.kt
@@ -3,9 +3,6 @@ package com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.pairtags
 import android.text.Spannable
 import android.text.SpannableStringBuilder
 import com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.TagApplier
-import com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.lonetags.BrLoneTagApplier
-import com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.lonetags.DummyLoneTagApplier
-import com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.lonetags.ImgLoneTagApplier
 import com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.lonetags.LoneTagApplier
 
 /**
@@ -15,7 +12,7 @@ import com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.lonetags.LoneT
  */
 abstract class PairTagApplier(partId: CharSequence) : TagApplier(partId) {
     /** Applies the html tag pair modified by properties specified by [args] to [contents]. */
-    abstract fun apply(args: List<CharSequence>, contents: SpannableStringBuilder)
+    abstract fun apply(args: List<Pair<CharSequence, CharSequence>>, contents: SpannableStringBuilder)
 
     /** Applies [spans], exclusive-exclusive, to the entire length of [target]. */
     protected fun applySpans(target: Spannable, vararg spans: Any) {

--- a/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/pairtags/SPairTagApplier.kt
+++ b/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/pairtags/SPairTagApplier.kt
@@ -2,7 +2,13 @@ package com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.pairtags
 
 import android.text.SpannableStringBuilder
 import android.text.style.StrikethroughSpan
+import com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.PairTagApplier
 
+/**
+ * PairTagApplier for the 's' html tag.
+ *
+ * @param[partId] The id of the source part to attribute unhandled arguments to.
+ */
 class SPairTagApplier(partId: CharSequence) : PairTagApplier(partId) {
     override fun apply(
         args: List<Pair<CharSequence, CharSequence>>, contents: SpannableStringBuilder

--- a/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/pairtags/SPairTagApplier.kt
+++ b/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/pairtags/SPairTagApplier.kt
@@ -1,0 +1,13 @@
+package com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.pairtags
+
+import android.text.SpannableStringBuilder
+import android.text.style.StrikethroughSpan
+
+class SPairTagApplier(partId: CharSequence) : PairTagApplier(partId) {
+    override fun apply(
+        args: List<Pair<CharSequence, CharSequence>>, contents: SpannableStringBuilder
+    ) {
+        warnIfArgsNotEmpty("em", args)
+        applySpans(contents, StrikethroughSpan())
+    }
+}

--- a/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/pairtags/SupPairTagApplier.kt
+++ b/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/pairtags/SupPairTagApplier.kt
@@ -1,19 +1,21 @@
 package com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.pairtags
 
 import android.text.SpannableStringBuilder
-import android.text.style.UnderlineSpan
+import android.text.style.RelativeSizeSpan
+import android.text.style.SuperscriptSpan
 import com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.PairTagApplier
 
 /**
- * PairTagApplier for the 'u' html tag.
+ * PairTagApplier for the 'sup' html tag.
  *
  * @param[partId] The id of the source part to attribute unhandled arguments to.
  */
-class UPairTagApplier(partId: CharSequence) : PairTagApplier(partId) {
+class SupPairTagApplier(partId: CharSequence) : PairTagApplier(partId) {
     override fun apply(
-        args: List<Pair<CharSequence, CharSequence>>, contents: SpannableStringBuilder
+        args: List<Pair<CharSequence, CharSequence>>,
+        contents: SpannableStringBuilder
     ) {
         warnIfArgsNotEmpty("b", args)
-        applySpans(contents, UnderlineSpan())
+        applySpans(contents, SuperscriptSpan(), RelativeSizeSpan(0.7f))
     }
 }

--- a/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/pairtags/UPairTagApplier.kt
+++ b/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/pairtags/UPairTagApplier.kt
@@ -1,0 +1,13 @@
+package com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.pairtags
+
+import android.text.SpannableStringBuilder
+import android.text.style.UnderlineSpan
+
+class UPairTagApplier(partId: CharSequence) : PairTagApplier(partId) {
+    override fun apply(
+        args: List<Pair<CharSequence, CharSequence>>, contents: SpannableStringBuilder
+    ) {
+        warnIfArgsNotEmpty("b", args)
+        applySpans(contents, UnderlineSpan())
+    }
+}

--- a/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/tagargs/ClassTagArgApplier.kt
+++ b/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/tagargs/ClassTagArgApplier.kt
@@ -1,0 +1,24 @@
+package com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.tagargs
+
+import android.text.SpannableStringBuilder
+import com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.TagArgApplier
+import com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.tagargs.classappliers.*
+
+/** [TagArgApplier] for the 'class' argument. */
+object ClassTagArgApplier : TagArgApplier {
+    override fun applyArg(value: CharSequence, contents: SpannableStringBuilder): Boolean {
+        val classes = value.trim(' ', '"').split(' ')
+        for (cls in classes) {
+            val applier = getClassApplier(cls) ?: return false
+            if (!applier.applyArg(cls, contents)) return false
+        }
+        return true
+    }
+
+    /** Returns the TagArgApplier for having class [cls]. */
+    private fun getClassApplier(cls: CharSequence): TagArgApplier? = when(cls) {
+        "centerp" -> CenterpApplier
+        "noindent" -> NoindentApplier
+        else -> null
+    }
+}

--- a/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/tagargs/ClassTagArgApplier.kt
+++ b/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/tagargs/ClassTagArgApplier.kt
@@ -19,6 +19,7 @@ object ClassTagArgApplier : TagArgApplier {
     private fun getClassApplier(cls: CharSequence): TagArgApplier? = when(cls) {
         "centerp" -> CenterpApplier
         "noindent" -> NoindentApplier
+        "signature" -> SignatureApplier
         else -> null
     }
 }

--- a/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/tagargs/classappliers/CenterpApplier.kt
+++ b/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/tagargs/classappliers/CenterpApplier.kt
@@ -1,0 +1,16 @@
+package com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.tagargs.classappliers
+
+import android.text.Layout
+import android.text.SpannableStringBuilder
+import android.text.style.AlignmentSpan
+import com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.TagApplier
+import com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.TagArgApplier
+
+/** [TagArgApplier] for the 'class' argument with value 'centerp'. */
+object CenterpApplier : TagArgApplier {
+    override fun applyArg(value: CharSequence, contents: SpannableStringBuilder): Boolean {
+        NoindentApplier.applyArg("noindent", contents)
+        TagApplier.applySpans(contents, AlignmentSpan.Standard(Layout.Alignment.ALIGN_CENTER))
+        return true
+    }
+}

--- a/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/tagargs/classappliers/NoindentApplier.kt
+++ b/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/tagargs/classappliers/NoindentApplier.kt
@@ -1,0 +1,16 @@
+package com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.tagargs.classappliers
+
+import android.text.SpannableStringBuilder
+import android.text.style.LeadingMarginSpan
+import com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.TagArgApplier
+
+/** [TagArgApplier] for the 'class' argument with value 'noindent'. */
+object NoindentApplier : TagArgApplier {
+    override fun applyArg(value: CharSequence, contents: SpannableStringBuilder): Boolean {
+        val leadingMarginSpan = contents.getSpans(
+            0, contents.length, LeadingMarginSpan::class.java
+        ).firstOrNull()
+        if (leadingMarginSpan != null) contents.removeSpan(leadingMarginSpan)
+        return true
+    }
+}

--- a/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/tagargs/classappliers/SignatureApplier.kt
+++ b/app/src/main/java/com/ytrewqwert/yetanotherjnovelreader/data/htmlparser/tags/tagargs/classappliers/SignatureApplier.kt
@@ -1,0 +1,16 @@
+package com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.tagargs.classappliers
+
+import android.text.Layout
+import android.text.SpannableStringBuilder
+import android.text.style.AlignmentSpan
+import com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.TagApplier
+import com.ytrewqwert.yetanotherjnovelreader.data.htmlparser.tags.TagArgApplier
+
+/** [TagArgApplier] for the 'class' argument with value 'signature'. */
+object SignatureApplier : TagArgApplier {
+    override fun applyArg(value: CharSequence, contents: SpannableStringBuilder): Boolean {
+        NoindentApplier.applyArg("noindent", contents)
+        TagApplier.applySpans(contents, AlignmentSpan.Standard(Layout.Alignment.ALIGN_OPPOSITE))
+        return true
+    }
+}


### PR DESCRIPTION
Fixes #39 and handles more values for the "class" argument to html tags.

Makes significant changes to make the handling/application of html tags to be more maintainable / cleaner to implement new tags/arguments.
(Hooray for design principles/patterns...)

Also worth noting is that the tag argument handling is now independent from the 'p' tag, although the handling is still restricted to that tag for now since that's the only tag that's had arguments appear in it (from what I've seen). It may be worth moving this logic up to perhaps the PartHtmlParser or HtmlTagApplier in the future, depending on if/how the arguments are used in other tags.